### PR TITLE
Improvements

### DIFF
--- a/docs/docs/02-HostPreparations/04-PackageInstall.md
+++ b/docs/docs/02-HostPreparations/04-PackageInstall.md
@@ -12,7 +12,7 @@ nav_order: 4
 Since everything in this guide is outlined for simply Arch, you may need to find the package equivalent to your system. Here is the command to install all required packages.
 
 ```
-sudo pacman -S virt-manager qemu vde2 ebtables iptables-nft nftables dnsmasq bridge-utils ovmf
+sudo pacman -S virt-manager qemu vde2 ebtables iptables-nft nftables dnsmasq bridge-utils ovmf dmg2img
 ```
 
 Please note: Conflicts may happen when installing these programs.

--- a/docs/docs/03-GatheringFiles/03-Kexts.md
+++ b/docs/docs/03-GatheringFiles/03-Kexts.md
@@ -10,15 +10,15 @@ nav_order: 4
 
 Here is a basic chart of a Kext, its use, and the status of the requirement. Check with the hardware you'll be passing through if you need any Kexts. For example, Samsung NVMe should be using NVMeFix.kext for better voltage and temperature management by macOS.
 
-| Kext  | Status | Description | 
+| Kext  | Status | Description |
 | ----- | ----- | ----- |
 | [Lilu](https://github.com/acidanthera/Lilu/releases) | Required | A kext to patch many processes, required for AppleALC, WhateverGreen, VirtualSMC and many other kexts. Without Lilu, they will not work. |
 | [WhateverGreen](https://github.com/acidanthera/WhateverGreen/releases) | Required | Used for graphics patching, DRM fixes, board ID checks, framebuffer fixes, etc; all GPUs benefit from this kext. |
 | [AppleMCEReporterDisabler](https://github.com/acidanthera/bugtracker/files/3703498/AppleMCEReporterDisabler.kext.zip) | Required | Required on macOS 12.3 and later on AMD systems and dual-socket Intel systems, and on KVM. |
+| [RestrictEvents](https://github.com/acidanthera/RestrictEvents/releases) | Recommended | Lilu plugin for blocking unwanted processes causing compatibility issues on different hardware and unlocking the support for certain features restricted to other hardware. Serves as a workaround for "Memory Modules Misconfigured" warning, among other issues. Can be used cosmetically for changing the name of the CPU. |
 | [VirtualSMC](https://github.com/acidanthera/VirtualSMC/releases) | Optional | Emulates the SMC chip found on real macs, but we are already emulating it from the XML file, this might be useful for kexts that send temperature info to the SMC, like SMCRadeonGPU. |
 | [AppleALC](https://github.com/acidanthera/AppleALC) | Optional | Used for [Front Panel Audio](../../writeups/04-FrontPanelAudio/index), Additional setup required! |
 | [NVMeFix](https://github.com/acidanthera/NVMeFix/releases) | Optional | NVMeFix is a set of patches for the Apple NVMe storage driver, IONVMeFamily. Its goal is to improve compatibility with non-Apple SSDs. It may be used both on Apple and non-Apple computers. Note: Does not work on Sonoma as of now. |
-| [RestrictEvents](https://github.com/acidanthera/RestrictEvents/releases) | Optional | Lilu plugin for blocking unwanted processes causing compatibility issues on different hardware and unlocking the support for certain features restricted to other hardware. We will mainly use it for changing the name of the CPU cosmetically. |
 | [RadeonSensor](https://github.com/NootInc/RadeonSensor/releases) | Optional | Kext and Gadget to show AMD GPU temperature on macOS. |
 | [AGPMInjector](https://github.com/Pavo-IM/AGPMInjector/releases) | Optional | Injects AGPM (Apple Graphics Power Management) to our non-Apple GPUs. |
 

--- a/docs/docs/04-Configs/01-VMCascadeLake/05-Misc.md
+++ b/docs/docs/04-Configs/01-VMCascadeLake/05-Misc.md
@@ -20,7 +20,7 @@ To be filled with plist string entries containing absolute UEFI paths to customi
 
 Don't skip over this section, we'll be changing the following:
 
-| Key  | Type | Value | 
+| Key  | Type | Value |
 | ----- | ----- | ----- |
 | HideAuxiliary | Boolean | True |
 | PollAppleHotKeys | Boolean | True |
@@ -30,7 +30,7 @@ Don't skip over this section, we'll be changing the following:
 Helpful for debugging OpenCore boot issues.
 Don't skip over this section, we'll be changing the following:
 
-| Key  | Type | Value | 
+| Key  | Type | Value |
 | ----- | ----- | ----- |
 | Target | Number | 67 |
 
@@ -43,14 +43,17 @@ Used for specifying irregular boot paths that can't be found naturally with Open
 Security is pretty self-explanatory, <b>do not skip</b>. We'll be changing the following:
 
 {: .warning }
-Optional is a word, you must type it out. It IS case-sensitive.
+Pay attention to values in red; those are case-sensitive.
 
-| Key  | Type | Value | 
+| Key  | Type | Value |
 | ----- | ----- | ----- |
 | AllowSetDefault | Boolean | True |
 | ExposeSensitiveData | Number | 15 |
 | ScanPolicy | Number | 0 |
+| SecureBootModel | String | <span style="color:red">Disabled</span> |
 | Vault | String | <span style="color:red">Optional</span> |
+
+SecurityBootModel (not to be confused with Secure Boot) can be set back to Default after successful install. We're disabling it for now to allow booting BaseSystem.img.
 
 ## Serial
 

--- a/docs/docs/05-FetchingBaseSystem/01-macrecovery.md
+++ b/docs/docs/05-FetchingBaseSystem/01-macrecovery.md
@@ -13,17 +13,17 @@ For this example, we'll be getting the latest macOS Ventura:
 
 ``python3 macrecovery.py -b Mac-4B682C642B45593E -m 00000000000000000 download``
 
+Notice that it will then create a folder ``com.apple.recovery.boot`` where the ``BaseSystem.dmg`` is located. Since the image is compressed, we have to convert it to standard (hfsplus) image. It can be achieved by using a tool like `dmg2img`:
+
+``dmg2img -i BaseSystem.dmg BaseSystem.img``
+
+## If you'd like to persist recovery in OpenCore.img
+
+Copy ``com.apple.recovery.boot`` folder over to the root of the OpenCore .img mount point. Do note that this way it loads greatly slower compared to attaching converted image directly to the Virtual Machine.
+
 <p align="center">
   <img src="../../assets/macrecovery.png">
 </p>
-
-Notice that it will then create a folder ``com.apple.recovery.boot``, which you will need to copy over to the root of the OpenCore .img mount point. Refer to the image above for an example. It does load slower this way, but will persist so you will always have it around, you can delete it after if you'd like. You can also use dmg2img to convert the BaseSystem.dmg to a BaseSystem.img you can then mount via Virt-Manager.
-
-## If you'd like to convert to an img
-
-If for whatever reason you'd like to mount this directly to the Virtual Machine, you'll have to convert the dmg to an img file. You can do this using ``dmg2img`` the following way
-
-``dmg2img -i BaseSystem.dmg BaseSystem.img``
 
 ## List of downloadable BaseSystems
 

--- a/docs/docs/06-InstallingmacOS/02-ConfigDrives.md
+++ b/docs/docs/06-InstallingmacOS/02-ConfigDrives.md
@@ -27,6 +27,10 @@ Don't forget to set it as your boot drive.
   <img src="../../assets/VManAddOpenCore2.png">
 </p>
 
+## Adding recoveryOS Drive
+
+Unless you had embedded the recovery in OpenCore.img, you don't need this step. Add the drive the same way you've added the OpenCore Drive.
+
 ## Creating a Virtual SSD for installation
 
 If you're not going to passthrough an NVME drive to install macOS on, then this is the step to make a disk image. You can choose any size you'd like but I suggest the standard 128G, 256GB, 500GB, 1000GB.


### PR DESCRIPTION
Made some improvements and corrections based on my (complete) install experience.

- Converting BaseImage.dmg to .img and attaching to the vm preferred, dmg2img now in required packages
- RestrictEvents recommended as a workaround to "Memory Modules Misconfigured" warning, at least until CMM section is done
- SecureBootModel now initially disabled and offered to be re-enabled after install so that OC can load BaseImage disk attached to the vm