### PR TITLE
Update DarwinPPC Template scripts

### DIFF
--- a/DarwinPPC/Template-Cheetah.sh
+++ b/DarwinPPC/Template-Cheetah.sh
@@ -5,11 +5,7 @@
 # GNU General Public License v3.0
 #
 
-if [ -z "$1" ]; then
-    hdd_path="../DiskProvision/images/Macintosh.img"
-else
-    hdd_path="$1"
-fi
+hdd_path="../DiskProvision/images/Macintosh.img"
 iso_path="../DarwinFetch/downloads/10.0.3_4P130/Mac OS X 10.0.3/Mac OS X 10.0.3.iso"
 
 # echo "HDD path is: $hdd_path"

--- a/DarwinPPC/Template-Cheetah.sh
+++ b/DarwinPPC/Template-Cheetah.sh
@@ -5,7 +5,11 @@
 # GNU General Public License v3.0
 #
 
-hdd_path="../DiskProvision/images/Macintosh.img"
+if [ -z "$1" ]; then
+    hdd_path="../DiskProvision/images/Macintosh.img"
+else
+    hdd_path="$1"
+fi
 iso_path="../DarwinFetch/downloads/10.0.3_4P130/Mac OS X 10.0.3/Mac OS X 10.0.3.iso"
 
 # echo "HDD path is: $hdd_path"
@@ -13,7 +17,7 @@ iso_path="../DarwinFetch/downloads/10.0.3_4P130/Mac OS X 10.0.3/Mac OS X 10.0.3.
 
 # Check if the HDD image exists
 if [ ! -f "$hdd_path" ]; then
-    echo "Could not open '$iso_path': No such file or directory"
+    echo "Could not open '$hdd_path': No such file or directory"
     exit 1
 fi
 

--- a/DarwinPPC/Template-Jaguar.sh
+++ b/DarwinPPC/Template-Jaguar.sh
@@ -5,11 +5,7 @@
 # GNU General Public License v3.0
 #
 
-if [ -z "$1" ]; then
-    hdd_path="../DiskProvision/images/Macintosh.img"
-else
-    hdd_path="$1"
-fi
+hdd_path="../DiskProvision/images/Macintosh.img"
 iso_path="../DarwinFetch/downloads/10.2.0_6C115/Apple Mac OS X 10.2 (10.2.6C115)/Disc1.iso"
 iso2_path="../DarwinFetch/downloads/10.2.0_6C115/Apple Mac OS X 10.2 (10.2.6C115)/Disc2.iso"
 

--- a/DarwinPPC/Template-Jaguar.sh
+++ b/DarwinPPC/Template-Jaguar.sh
@@ -5,7 +5,11 @@
 # GNU General Public License v3.0
 #
 
-hdd_path="../DiskProvision/images/Macintosh.img"
+if [ -z "$1" ]; then
+    hdd_path="../DiskProvision/images/Macintosh.img"
+else
+    hdd_path="$1"
+fi
 iso_path="../DarwinFetch/downloads/10.2.0_6C115/Apple Mac OS X 10.2 (10.2.6C115)/Disc1.iso"
 iso2_path="../DarwinFetch/downloads/10.2.0_6C115/Apple Mac OS X 10.2 (10.2.6C115)/Disc2.iso"
 
@@ -14,7 +18,7 @@ iso2_path="../DarwinFetch/downloads/10.2.0_6C115/Apple Mac OS X 10.2 (10.2.6C115
 
 # Check if the HDD image exists
 if [ ! -f "$hdd_path" ]; then
-    echo "Could not open '$iso_path': No such file or directory"
+    echo "Could not open '$hdd_path': No such file or directory"
     exit 1
 fi
 

--- a/DarwinPPC/Template-Leopard.sh
+++ b/DarwinPPC/Template-Leopard.sh
@@ -5,11 +5,7 @@
 # GNU General Public License v3.0
 #
 
-if [ -z "$1" ]; then
-    hdd_path="../DiskProvision/images/Macintosh.img"
-else
-    hdd_path="$1"
-fi
+hdd_path="../DiskProvision/images/Macintosh.img"
 iso_path="../DarwinFetch/downloads/10.5.6_00000/Mac OS X 10.5.6/Mac OS X 10.5.6.iso"
 
 # echo "HDD path is: $hdd_path"

--- a/DarwinPPC/Template-Leopard.sh
+++ b/DarwinPPC/Template-Leopard.sh
@@ -5,7 +5,11 @@
 # GNU General Public License v3.0
 #
 
-hdd_path="../DiskProvision/images/Macintosh.img"
+if [ -z "$1" ]; then
+    hdd_path="../DiskProvision/images/Macintosh.img"
+else
+    hdd_path="$1"
+fi
 iso_path="../DarwinFetch/downloads/10.5.6_00000/Mac OS X 10.5.6/Mac OS X 10.5.6.iso"
 
 # echo "HDD path is: $hdd_path"
@@ -13,7 +17,7 @@ iso_path="../DarwinFetch/downloads/10.5.6_00000/Mac OS X 10.5.6/Mac OS X 10.5.6.
 
 # Check if the HDD image exists
 if [ ! -f "$hdd_path" ]; then
-    echo "Could not open '$iso_path': No such file or directory"
+    echo "Could not open '$hdd_path': No such file or directory"
     exit 1
 fi
 

--- a/DarwinPPC/Template-Panther.sh
+++ b/DarwinPPC/Template-Panther.sh
@@ -5,11 +5,7 @@
 # GNU General Public License v3.0
 #
 
-if [ -z "$1" ]; then
-    hdd_path="../DiskProvision/images/Macintosh.img"
-else
-    hdd_path="$1"
-fi
+hdd_path="../DiskProvision/images/Macintosh.img"
 iso_path="../DarwinFetch/downloads/10.3.0_7B850/Panther_CD1.toast_/Panther_Disc1.toast"
 iso2_path="../DarwinFetch/downloads/10.3.0_7B850/Panther_CD2.toast_/Panther_Disc2.toast"
 iso3_path="../DarwinFetch/downloads/10.3.0_7B850/Panther_CD3.toast__0/Panther_Disc3.toast"

--- a/DarwinPPC/Template-Panther.sh
+++ b/DarwinPPC/Template-Panther.sh
@@ -5,7 +5,11 @@
 # GNU General Public License v3.0
 #
 
-hdd_path="../DiskProvision/images/Macintosh.img"
+if [ -z "$1" ]; then
+    hdd_path="../DiskProvision/images/Macintosh.img"
+else
+    hdd_path="$1"
+fi
 iso_path="../DarwinFetch/downloads/10.3.0_7B850/Panther_CD1.toast_/Panther_Disc1.toast"
 iso2_path="../DarwinFetch/downloads/10.3.0_7B850/Panther_CD2.toast_/Panther_Disc2.toast"
 iso3_path="../DarwinFetch/downloads/10.3.0_7B850/Panther_CD3.toast__0/Panther_Disc3.toast"
@@ -15,7 +19,7 @@ iso3_path="../DarwinFetch/downloads/10.3.0_7B850/Panther_CD3.toast__0/Panther_Di
 
 # Check if the HDD image exists
 if [ ! -f "$hdd_path" ]; then
-    echo "Could not open '$iso_path': No such file or directory"
+    echo "Could not open '$hdd_path': No such file or directory"
     exit 1
 fi
 

--- a/DarwinPPC/Template-Puma.sh
+++ b/DarwinPPC/Template-Puma.sh
@@ -5,7 +5,11 @@
 # GNU General Public License v3.0
 #
 
-hdd_path="../DiskProvision/images/Macintosh.img"
+if [ -z "$1" ]; then
+    hdd_path="../DiskProvision/images/Macintosh.img"
+else
+    hdd_path="$1"
+fi
 iso_path="../DarwinFetch/downloads/10.1.0_5G640/Apple Mac OS X 10.1 (10.1.5J34)/Mac OS X Install CD.iso"
 
 # echo "HDD path is: $hdd_path"
@@ -13,7 +17,7 @@ iso_path="../DarwinFetch/downloads/10.1.0_5G640/Apple Mac OS X 10.1 (10.1.5J34)/
 
 # Check if the HDD image exists
 if [ ! -f "$hdd_path" ]; then
-    echo "Could not open '$iso_path': No such file or directory"
+    echo "Could not open '$hdd_path': No such file or directory"
     exit 1
 fi
 

--- a/DarwinPPC/Template-Puma.sh
+++ b/DarwinPPC/Template-Puma.sh
@@ -5,11 +5,7 @@
 # GNU General Public License v3.0
 #
 
-if [ -z "$1" ]; then
-    hdd_path="../DiskProvision/images/Macintosh.img"
-else
-    hdd_path="$1"
-fi
+hdd_path="../DiskProvision/images/Macintosh.img"
 iso_path="../DarwinFetch/downloads/10.1.0_5G640/Apple Mac OS X 10.1 (10.1.5J34)/Mac OS X Install CD.iso"
 
 # echo "HDD path is: $hdd_path"

--- a/DarwinPPC/Template-SnowLeopard.sh
+++ b/DarwinPPC/Template-SnowLeopard.sh
@@ -5,7 +5,11 @@
 # GNU General Public License v3.0
 #
 
-hdd_path="../DiskProvision/images/Macintosh.img"
+if [ -z "$1" ]; then
+    hdd_path="../DiskProvision/images/Macintosh.img"
+else
+    hdd_path="$1"
+fi
 iso_path="../DarwinFetch/downloads/"
 
 # echo "HDD path is: $hdd_path"
@@ -13,7 +17,7 @@ iso_path="../DarwinFetch/downloads/"
 
 # Check if the HDD image exists
 if [ ! -f "$hdd_path" ]; then
-    echo "Could not open '$iso_path': No such file or directory"
+    echo "Could not open '$hdd_path': No such file or directory"
     exit 1
 fi
 

--- a/DarwinPPC/Template-SnowLeopard.sh
+++ b/DarwinPPC/Template-SnowLeopard.sh
@@ -5,11 +5,7 @@
 # GNU General Public License v3.0
 #
 
-if [ -z "$1" ]; then
-    hdd_path="../DiskProvision/images/Macintosh.img"
-else
-    hdd_path="$1"
-fi
+hdd_path="../DiskProvision/images/Macintosh.img"
 iso_path="../DarwinFetch/downloads/"
 
 # echo "HDD path is: $hdd_path"

--- a/DarwinPPC/Template-Tiger.sh
+++ b/DarwinPPC/Template-Tiger.sh
@@ -5,12 +5,7 @@
 # GNU General Public License v3.0
 #
 
-if [ -z "$1" ]; then
-    hdd_path="../DiskProvision/images/Macintosh.img"
-else
-    hdd_path="$1"
-fi
-
+hdd_path="../DiskProvision/images/Macintosh.img"
 iso_path="../DarwinFetch/downloads/10.4.8_8L127/Mac OS X 10.4.8/Mac OS X 10.4.8.iso"
 
 # echo "HDD path is: $hdd_path"

--- a/DarwinPPC/Template-Tiger.sh
+++ b/DarwinPPC/Template-Tiger.sh
@@ -5,7 +5,12 @@
 # GNU General Public License v3.0
 #
 
-hdd_path="../DiskProvision/images/Macintosh.img"
+if [ -z "$1" ]; then
+    hdd_path="../DiskProvision/images/Macintosh.img"
+else
+    hdd_path="$1"
+fi
+
 iso_path="../DarwinFetch/downloads/10.4.8_8L127/Mac OS X 10.4.8/Mac OS X 10.4.8.iso"
 
 # echo "HDD path is: $hdd_path"

--- a/DarwinPPC/Template-Tiger.sh
+++ b/DarwinPPC/Template-Tiger.sh
@@ -13,7 +13,7 @@ iso_path="../DarwinFetch/downloads/10.4.8_8L127/Mac OS X 10.4.8/Mac OS X 10.4.8.
 
 # Check if the HDD image exists
 if [ ! -f "$hdd_path" ]; then
-    echo "Could not open '$iso_path': No such file or directory"
+    echo "Could not open '$hdd_path': No such file or directory"
     exit 1
 fi
 


### PR DESCRIPTION
Fix incorrect path in error printout

I spent half an hour losing my mind as to why Bash would tell me a file did not exist that absolutely did exist, and had proper permissions, only to realize that the script was failing to find the HDD image, but telling me it was failing to find the CD image. 